### PR TITLE
implement Evaluation method

### DIFF
--- a/R/main.R
+++ b/R/main.R
@@ -35,7 +35,7 @@ processFiles <- function(
 
   # rules
   rules <- if (rules.file == "") {
-    scrambling.rules
+    scrambler::scrambling.rules
   } else {
     loadRules(rules.file)
   }

--- a/R/scrambe.R
+++ b/R/scrambe.R
@@ -19,7 +19,7 @@ scrambleDataFrame <- function(data, seed = 100, scrambling.rules) {
 
     write.log("scrambling", col, "using", method, "method")
     scr <- data
-    scr[, c(col)] <- scrambleValue(data[, col], method, seed, mparam, max.len)
+    scr[, c(col)] <- scrambleValue(data[, col], method, seed, mparam, max.len, data)
 
     return(scr)
   }
@@ -39,9 +39,14 @@ scrambleDataFrame <- function(data, seed = 100, scrambling.rules) {
 #' @param method - obfuscation bethod. Supported methods are \code{shuffle},
 #'   \code{hash}, \code{random.hash}, \code{random.num}, \code{rnorm.num}
 #' @param seed - seed value for random generation and sampling
-#' @param method.param - additional information associated with method; for example hash algorithm or exact fixed value
-#' @param max.len - maximum length of scrabled value (useful when data column is of limited length)
-scrambleValue <- function(value, method, seed = 100, method.param = "", max.len) {
+#' @param method.param - additional information associated with method; for
+#'   example hash algorithm or exact fixed value
+#' @param max.len - maximum length of scrabled value (useful when data column is
+#'   of limited length)
+#' @param data - data frame optionaly provided for evaluation (method = eval);
+#'   columns of data frame can be addressed directly or via \code{data} alias
+#'   (like \code{data$Field} to get data from \code{Field})
+scrambleValue <- function(value, method, seed = 100, method.param = "", max.len, data = NULL) {
   set.seed(seed)
   result <- if (method == "shuffle") {
     shuffle(value)
@@ -57,6 +62,8 @@ scrambleValue <- function(value, method, seed = 100, method.param = "", max.len)
     random.date(value)
   } else if (method == "fixed.value") {
     fixed.value(value, method.param)
+  } else if (method == "eval") {
+    eval.formula(value, method.param, data)
   } else {
     fixed.value(value, method.param)
   }
@@ -107,4 +114,12 @@ random.hash <- function(method.param) {
 
 fixed.value <- function(v, fix.value) {
   replicate(length(v), fix.value)
+}
+
+eval.formula <- function(x, formula, data) {
+  result <- with(
+    data,
+    eval(parse(text = formula))
+  )
+  result
 }

--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ List of supported methods and their parameters
 | random.num  |             | Generate random numbers using mean value and standard deviation of numbers provided. Keep empty and zero values. |
 | rnorm.num   |             | Generate random numbers with maen = 0 and standard deviation of given values; add generated values to given values. Keep empty and zero values. |
 | fixed.value | value       | Use fixed value given as a parameter |
+| eval        | formula     | Apply formula t ovalue (referring to value as `x` or dereffing to data as `data`. Example formulas: `"x + x"` or `"x + data$Balance"`  or `"Balance + Charges"`|
 
 ## Examples
 

--- a/man/scrambleValue.Rd
+++ b/man/scrambleValue.Rd
@@ -4,7 +4,8 @@
 \alias{scrambleValue}
 \title{Scramble values}
 \usage{
-scrambleValue(value, method, seed = 100, method.param = "", max.len)
+scrambleValue(value, method, seed = 100, method.param = "", max.len,
+  data = NULL)
 }
 \arguments{
 \item{value}{- vector of values to scramble}
@@ -14,9 +15,15 @@ scrambleValue(value, method, seed = 100, method.param = "", max.len)
 
 \item{seed}{- seed value for random generation and sampling}
 
-\item{method.param}{- additional information associated with method; for example hash algorithm or exact fixed value}
+\item{method.param}{- additional information associated with method; for
+example hash algorithm or exact fixed value}
 
-\item{max.len}{- maximum length of scrabled value (useful when data column is of limited length)}
+\item{max.len}{- maximum length of scrabled value (useful when data column is
+of limited length)}
+
+\item{data}{- data frame optionaly provided for evaluation (method = eval);
+columns of data frame can be addressed directly or via \code{data} alias
+(like \code{data$Field} to get data from \code{Field})}
 }
 \description{
 The function scrambles vector or values based on method provided

--- a/tests/testthat/test-scramble.R
+++ b/tests/testthat/test-scramble.R
@@ -80,11 +80,50 @@ test_that("scramble data.frame", {
     stringsAsFactors = F,
     Column = c("Client", "Account"),
     Method = c("hash", "hash"),
-    Fixed.Value = c("", ""),
+    Method.Param = c("sha1", "sha256"),
     Max.Length  = c("", "16")
   )
   sd <- scrambleDataFrame(df, scrambling.rules = sr)
   expect_true(TRUE)
+})
+
+test_that("scramble data frame using eval method", {
+  df <- data.frame(
+    stringsAsFactors = F,
+    Client  = c("Client 1", "Client 2", "Client 3"),
+    Account = c("Account 1", "Account 2", "Account 3"),
+    Balance = c(100, 200, 300)
+  )
+  sr <- data.frame(
+    stringsAsFactors = F,
+    Column = c("Balance"),
+    Method = c("eval"),
+    Method.Param  = "(x + 1333) / 1344 + Balance",
+    Max.Length  = c(NA)
+  )
+  sd <- scrambleDataFrame(df, scrambling.rules = sr)
+  expect_equal((df$Balance + 1333) / 1344 + df$Balance, sd$Balance)
+})
+
+test_that("scramble using eval method: access by \"x\"",{
+  data <- data.frame(
+    stringsAsFactors = F,
+    Balance = c(100, 200, 300),
+    Charges = c(1, 7, 3)
+  )
+  fun <- function(x, formula) {
+    scrambleValue(
+      value = x, method = "eval", seed = 123,
+      method.param = formula, max.len = NA, data = data
+    )
+  }
+  x <- data$Balance
+
+  expect_equal(fun(x, "x + x"            ), x + x)
+  expect_equal(fun(x, "x + data$Balance" ), x + data$Balance)
+  expect_equal(fun(x, "x + data[[1]]"    ), x + data[[1]])
+  expect_equal(fun(x, "Balance + Charges"), data$Balance + data$Charges)
+
 })
 
 save_testfile <- function(lines, filename) {


### PR DESCRIPTION
This PR resolves #9 

Sometimes users want to provide arithmetic formula to calculate amount. 

For these cases new method was implemented. it is called `eval`as a parameter this method accepts any valid R expression. for example: `(x + 7) / (2 * x)`

User can refer:
* either value to be scrambled by `x`
* or dataframe to be scrambled using `data$` prefix followed by field name (e.g. `data$Balance`)
* or just name from dataframe (e.g. `Balane`)
* or combination of this

Below is working example from tests
```R
  data <- data.frame(
    stringsAsFactors = F,
    Balance = c(100, 200, 300),
    Charges = c(1, 7, 3)
  )
  fun <- function(x, formula) {
    scrambleValue(
      value = x, method = "eval", seed = 123,
      method.param = formula, max.len = NA, data = data
    )
  }
  x <- data$Balance

  expect_equal(fun(x, "x + x"            ), x + x)
  expect_equal(fun(x, "x + data$Balance" ), x + data$Balance)
  expect_equal(fun(x, "x + data[[1]]"    ), x + data[[1]])
  expect_equal(fun(x, "Balance + Charges"), data$Balance + data$Charges)
```